### PR TITLE
Agregado código para reconocer desconexión/reconexión wifi y ver reflejado cambios en los leds

### DIFF
--- a/TP_Baliza/src/Baliza.cpp
+++ b/TP_Baliza/src/Baliza.cpp
@@ -26,10 +26,12 @@ void Baliza::apagarLed(int led){
 }
 
 void Baliza::parpadearLed(int led){
-    digitalWrite(led, HIGH);
-    delay(300);
-    digitalWrite(led, LOW);
-    delay(300);
+    for(int i = 0; i <= 3; i++){
+        digitalWrite(led, HIGH);
+        delay(300);
+        digitalWrite(led, LOW);
+        delay(300);
+    }
 }
 
 void Baliza::parpadearVerdeYRojo(){

--- a/TP_Baliza/src/RedWifi.cpp
+++ b/TP_Baliza/src/RedWifi.cpp
@@ -17,3 +17,7 @@ void RedWifi::conectar(){
 
     Serial.println("WiFi connected.");
 }
+
+int RedWifi::chequearConexion(){
+    return (WiFi.status() == WL_CONNECTED);
+}

--- a/TP_Baliza/src/RedWifi.h
+++ b/TP_Baliza/src/RedWifi.h
@@ -3,6 +3,7 @@ class RedWifi
     public:
     RedWifi(const char* ssid, const char* password);
     void conectar();
+    int chequearConexion();
 
     private:
     const char* _ssid;

--- a/TP_Baliza/src/main.cpp
+++ b/TP_Baliza/src/main.cpp
@@ -8,27 +8,47 @@
 
 Baliza* baliza = new Baliza;
 ConsultorServidorTravis* consultor = new ConsultorServidorTravis;
+RedWifi* red = new RedWifi("Hernan95", "perroloco");
 String ultimoEstado;
 String estadoActual;
+int fueReconectado = 0;
 
 void setup() {
   Serial.begin(115200);
   
-  RedWifi red("Hernan95", "perroloco");
-  red.conectar();
+  red->conectar();
  
   ultimoEstado = consultor->obtenerEstado();
 }
 
 void loop() {
+  if(!red->chequearConexion()){
+    baliza->apagarLed(13);
+    baliza->apagarLed(25);
+    while(!red->chequearConexion()){
+      baliza->encenderLed(27);
+    }
+    baliza->apagarLed(27);
+    fueReconectado = 1;
+  }
+
   estadoActual = consultor->obtenerEstado();
-  Serial.println(estadoActual.equals("Exitoso")==0);
+
   if(estadoActual.equals("Exitoso")==0){
+    baliza->apagarLed(13);
+    if(estadoActual != ultimoEstado || fueReconectado){
+      baliza->parpadearLed(25);
+    }
     baliza->encenderLed(25);
   } else if(estadoActual.equals("Fallido")==0){
+    baliza->apagarLed(25);
+    if(estadoActual != ultimoEstado || fueReconectado){
+      baliza->parpadearLed(13);
+    }
     baliza->encenderLed(13);
   } else if(estadoActual.equals("En progreso")==0){
     baliza->parpadearVerdeYRojo();
   }
+  fueReconectado = 0;
   delay(200);
 }


### PR DESCRIPTION
Hola Lucas! Básicamente lo que hice fue:

Agregué el método chequearConexión en RedWifi.
Modifiqué el método parpadearLed en Baliza para que un led parpadee 3 veces.
Agregué código en el main para chequear la conexión wifi y reflejar cambios mediante los leds (desconexión/reconexión al wifi y cambios en el ultimo estado del build y el actual)

